### PR TITLE
Clear feedback after submitting to avoid duplicates

### DIFF
--- a/code-review-actions.el
+++ b/code-review-actions.el
@@ -185,6 +185,7 @@ If you want only to submit replies, use ONLY-REPLY? as non-nil."
                (let ((code-review-section-full-refresh? t))
                  (oset pr finished t)
                  (oset pr finished-at (current-time-string))
+                 (oset pr feedback nil)
                  (code-review-db-update pr)
                  (code-review--build-buffer
                   code-review-buffer-name


### PR DESCRIPTION
Without this, it's easy to post duplicate feedback if you continue a review.