### PR TITLE
Replace ghub-graphql with ghub-query

### DIFF
--- a/code-review-github.el
+++ b/code-review-github.el
@@ -57,24 +57,31 @@
 (defun code-review-github-errback (&rest m)
   "Error callback, displays the error message M."
   (code-review-utils--log "code-review-github-errback" (prin1-to-string m))
-  (let-alist m
-    (let* ((status (-second-item .error)))
-      (cond
-       ((= status 422)
-        (let ((errors (string-join
-                       (a-get (-third-item .error) 'errors)
-                       " AND "))
-              (msg (string-trim (a-get (-third-item .error) 'message))))
-          (message "Errors: %S" (if (string-empty-p errors)
-                                    msg
-                                  (string-join (list msg errors) ". ")))))
-       ((= status 404)
-        (message "Provided URL Not Found"))
-       ((= status 401)
-        (message "Bad credentials. Documentation to how to setup credentials
+  (if-let* ((first (car m))
+            ((listp first))
+            ((eq (car-safe first) 'errors))
+            (graphql-errors (cdr first))
+            (msgs (mapcar (lambda (e) (or (a-get e 'message) (prin1-to-string e)))
+                          graphql-errors)))
+      (message "GraphQL errors: %s" (string-join msgs "; "))
+    (let-alist m
+      (let* ((status (-second-item .error)))
+        (cond
+         ((= status 422)
+          (let ((errors (string-join
+                         (a-get (-third-item .error) 'errors)
+                         " AND "))
+                (msg (string-trim (a-get (-third-item .error) 'message))))
+            (message "Errors: %S" (if (string-empty-p errors)
+                                      msg
+                                    (string-join (list msg errors) ". ")))))
+         ((= status 404)
+          (message "Provided URL Not Found"))
+         ((= status 401)
+          (message "Bad credentials. Documentation to how to setup credentials
 https://github.com/wandersoncferreira/code-review#configuration"))
-       (t
-        (message "Unknown error talking to Github: %s" m))))))
+         (t
+          (message "Unknown error talking to Github: %s" m)))))))
 
 (cl-defmethod code-review-pullreq-diff ((github code-review-github-repo) callback)
   "Get PR diff from GITHUB, run CALLBACK after answer."
@@ -203,6 +210,13 @@ https://github.com/wandersoncferreira/code-review#configuration"))
               state
               contexts(first:50){
                 nodes {
+                  ... on StatusContext {
+                    createdAt
+                    context
+                    state
+                    targetUrl
+                    description
+                  }
                   ... on CheckRun {
                     startedAt
                     completedAt
@@ -221,13 +235,6 @@ https://github.com/wandersoncferreira/code-review#configuration"))
                         slug
                         logoUrl
                       }
-                    }
-                  ... on StatusContext {
-                    createdAt
-                    context
-                    state
-                    targetUrl
-                    description
                     }
                   }
                 }
@@ -501,12 +508,12 @@ https://github.com/wandersoncferreira/code-review#configuration"))
                   repo
                   owner
                   num)))
-    (ghub-graphql query
-                  nil
-                  :auth code-review-auth-login-marker
-                  :host code-review-github-graphql-host
-                  :callback callback
-                  :errorback #'code-review-github-errback)))
+    (ghub-query query
+                nil
+                :auth code-review-auth-login-marker
+                :host code-review-github-graphql-host
+                :callback callback
+                :errorback #'code-review-github-errback)))
 
 (cl-defmethod code-review-infos-deferred ((github code-review-github-repo) &optional fallback?)
   "Get PR infos from GITHUB using deferred lib.
@@ -831,12 +838,12 @@ For GitHub, use line/side and optional start_line/start_side for comments."
       (let ((has-next-page t)
             cursor res)
         (while has-next-page
-          (let ((graphql-res (ghub-graphql query
-                                           `((repo_owner . ,(oref github owner))
-                                             (repo_name . ,(oref github repo))
-                                             (cursor . ,cursor))
-                                           :auth code-review-auth-login-marker
-                                           :host code-review-github-graphql-host)))
+          (let ((graphql-res (ghub-query query
+                                         `((repo_owner . ,(oref github owner))
+                                           (repo_name . ,(oref github repo))
+                                           (cursor . ,cursor))
+                                         :auth code-review-auth-login-marker
+                                         :host code-review-github-graphql-host)))
             (let-alist graphql-res
               (setq has-next-page .data.repository.assignableUsers.pageInfo.hasNextPage
                     cursor .data.repository.assignableUsers.pageInfo.endCursor
@@ -856,15 +863,15 @@ For GitHub, use line/side and optional start_line/start_side for comments."
 }
 ")
         (pr-id (a-get (oref github raw-infos) 'id)))
-    (ghub-graphql query
-                  `((input . ((pullRequestId . ,pr-id)
-                              (userIds . ,user-ids))))
-                  :auth code-review-auth-login-marker
-                  :host code-review-github-graphql-host
-                  :callback (lambda (&rest _)
-                              (message "Review requested successfully!")
-                              (funcall callback))
-                  :errorback #'code-review-github-errback)))
+    (ghub-query query
+                `((input . ((pullRequestId . ,pr-id)
+                            (userIds . ,user-ids))))
+                :auth code-review-auth-login-marker
+                :host code-review-github-graphql-host
+                :callback (lambda (&rest _)
+                            (message "Review requested successfully!")
+                            (funcall callback))
+                :errorback #'code-review-github-errback)))
 
 (cl-defmethod code-review-new-issue ((github code-review-github-repo) body title callback)
   "Create a new issue in GITHUB given a BODY and TITLE and call CALLBACK."

--- a/code-review-section.el
+++ b/code-review-section.el
@@ -1956,9 +1956,9 @@ If you want to display a minibuffer MSG in the end."
 
 (cl-defmethod code-review--internal-build ((_github code-review-github-repo) progress res &optional buff-name msg)
   "Helper function to build process for GITHUB based on the fetched RES informing PROGRESS."
-  (let* ((errors-complete-query (a-get (-second-item res) 'errors))
-         (raw-infos-complete (a-get-in (-second-item res) (list 'data 'repository 'pullRequest)))
-         (raw-infos-fallback (a-get-in (-third-item res) (list 'data 'repository 'pullRequest)))
+  (let* ((errors-complete-query (alist-get 'errors (-second-item res)))
+         (raw-infos-complete (a-get-in (cdr (-second-item res)) (list 'repository 'pullRequest)))
+         (raw-infos-fallback (a-get-in (cdr (-third-item res)) (list 'repository 'pullRequest)))
          (raw-infos
           (if (not raw-infos-complete)
               raw-infos-fallback

--- a/code-review.el
+++ b/code-review.el
@@ -8,7 +8,7 @@
 ;; Version: 0.0.7
 ;; Keywords: git, tools, vc
 ;; Homepage: https://github.com/wandersoncferreira/code-review
-;; Package-Requires: ((emacs "28.1") (closql "2.3") (magit "3.0.0") (transient "0.3.7") (a "1.0.0") (ghub "3.5.1") (uuidgen "1.2") (deferred "0.5.1") (markdown-mode "2.4") (forge "0.3.0") (emojify "1.2") (s "1.13.1"))
+;; Package-Requires: ((emacs "28.1") (closql "2.3") (magit "3.0.0") (transient "0.3.7") (a "1.0.0") (ghub "5.0.0") (uuidgen "1.2") (deferred "0.5.1") (markdown-mode "2.4") (forge "0.3.0") (emojify "1.2") (s "1.13.1"))
 
 ;; This file is not part of GNU Emacs
 


### PR DESCRIPTION
This increases the requirement to ghub-5.0.0, but the old signature is legacy and no longer required by default as of ghub-5.1.0.